### PR TITLE
fix rule names so other ANTLR4 targets work

### DIFF
--- a/src/main/antlr4/com/tr/rp/parser/RankPL.g4
+++ b/src/main/antlr4/com/tr/rp/parser/RankPL.g4
@@ -87,8 +87,8 @@ expr5
 
 expr6
  : INT													# LiteralIntExpression
- | True				 					 				# LiteralBoolExpr
- | False			 					 				# LiteralBoolExpr
+ | bool_True				 					 			# LiteralBoolExpr
+ | bool_False			 					 				# LiteralBoolExpr
  | QUOTED_STRING										# LiteralStringExpr
  | Infer '(' VAR ('()' | ('(' (exp (',' exp)*) ')')) ')'# InferringFunctionCall
  | VAR ('()' | ('(' (exp (',' exp)*) ')'))				# FunctionCall
@@ -127,8 +127,8 @@ Assert: 		'assert' | 'ASSERT';
 AssertRanked: 	'assert-ranked' | 'ASSERT-RANKED';
 Reset: 			'reset' | 'RESET';
 Break: 			'break' | 'BREAK';
-True: 			'true' | 'TRUE';
-False: 			'false' | 'FALSE';
+bool_True: 		'true' | 'TRUE';
+bool_False:		'false' | 'FALSE';
 Infer: 			'infer' | 'INFER';
 CurrentRank: 	'currentrank' | 'CURRENTRANK' | 'currentRank';
 


### PR DESCRIPTION
First triggered by using ANTLR4 Python backend where True and False are
reserved key-words and as such the generated Python code by ANTLR4 won't
work. This solves the issue without changing the underlying DSL that is
being parsed by this ANTLR4 grammar.